### PR TITLE
add headless browser support

### DIFF
--- a/BROWSER.md
+++ b/BROWSER.md
@@ -26,3 +26,10 @@ build -t mcr.microsoft.com/playwright/java:focal . -f Dockerfile.focal
 # cd back into the sparql-anything git repo
 docker run --rm -it -p 3000:3000 -v `pwd`:/mnt mcr.microsoft.com/playwright/java:focal bash -c 'cd /mnt ; mvn package ; java -cp /root/.m2/repository/org/slf4j/slf4j-simple/1.7.7/slf4j-simple-1.7.7.jar:/mnt/sparql.anything.fuseki/target/sparql-anything-fuseki-0.3.0-SNAPSHOT.jar com.github.spiceh2020.sparql.anything.fuseki.Endpoint'
 ```
+
+
+
+## Notes
+
+The first time you run a SPARQL query using the headless browser [Playwright](https://playwright.dev/java/) will download the browsers.
+If you deploy this SPARQL-Anything-powered Fuseki endpoint (in this docker container) you will likely want to put a volume at the path there the browsers are saved so they don't have to be downloaded each time you start the container.

--- a/BROWSER.md
+++ b/BROWSER.md
@@ -1,10 +1,10 @@
 # Headless Browser
 
-## SPARQL Anything Inside a Docker Container
+## SPARQL-Anything-powered Fuseki Endpoint Inside a Docker Container
 
 
 The [headless browser](https://github.com/microsoft/playwright-java) has quite a few dependencies.
-You can run it natively if you get them all but it is easier to just run SPARQL Anything in a docker container (containing all the required dependencies) when you know you need to the use the browser.
+You can run it natively if you get them all but it is easier to just run SPARQL-Anything in a docker container (containing all the required dependencies) when you know you need to the use the browser.
 
 Option 1 (use a prebuilt docker image)
 
@@ -13,6 +13,8 @@ Run this (in a bash shell):
 # cd into the sparql-anything git repo
 docker run --rm -it -p 3000:3000 -v `pwd`:/mnt mcr.microsoft.com/playwright/java:focal bash -c 'cd /mnt ; mvn package ; java -cp /root/.m2/repository/org/slf4j/slf4j-simple/1.7.7/slf4j-simple-1.7.7.jar:/mnt/sparql.anything.fuseki/target/sparql-anything-fuseki-0.3.0-SNAPSHOT.jar com.github.spiceh2020.sparql.anything.fuseki.Endpoint'
 ```
+
+<br/>
 
 Option 2 (build your own docker image)
 

--- a/BROWSER.md
+++ b/BROWSER.md
@@ -3,10 +3,11 @@
 ## SPARQL Anything Inside a Docker Container
 
 
-The headless browser has quite a few dependencies.
+The [headless browser](https://github.com/microsoft/playwright-java) has quite a few dependencies.
 You can run it natively if you get them all but it is easier to just run SPARQL Anything in a docker container (containing all the required dependencies) when you know you need to the use the browser.
 
 Option 1 (use a prebuilt docker image)
+
 Run this (in a bash shell):
 ```
 # cd into the sparql-anything git repo
@@ -14,6 +15,7 @@ docker run --rm -it -p 3000:3000 -v `pwd`:/mnt mcr.microsoft.com/playwright/java
 ```
 
 Option 2 (build your own docker image)
+
 Run this (in a bash shell):
 ```
 git clone https://github.com/microsoft/playwright-java.git

--- a/BROWSER.md
+++ b/BROWSER.md
@@ -1,0 +1,24 @@
+# Headless Browser
+
+## SPARQL Anything Inside a Docker Container
+
+
+The headless browser has quite a few dependencies.
+You can run it natively if you get them all but it is easier to just run SPARQL Anything in a docker container (containing all the required dependencies) when you know you need to the use the browser.
+
+Option 1 (use a prebuilt docker image)
+Run this (in a bash shell):
+```
+# cd into the sparql-anything git repo
+docker run --rm -it -p 3000:3000 -v `pwd`:/mnt mcr.microsoft.com/playwright/java:focal bash -c 'cd /mnt ; mvn package ; java -cp /root/.m2/repository/org/slf4j/slf4j-simple/1.7.7/slf4j-simple-1.7.7.jar:/mnt/sparql.anything.fuseki/target/sparql-anything-fuseki-0.3.0-SNAPSHOT.jar com.github.spiceh2020.sparql.anything.fuseki.Endpoint'
+```
+
+Option 2 (build your own docker image)
+Run this (in a bash shell):
+```
+git clone https://github.com/microsoft/playwright-java.git
+cd playwright-java
+build -t mcr.microsoft.com/playwright/java:focal . -f Dockerfile.focal
+# cd back into the sparql-anything git repo
+docker run --rm -it -p 3000:3000 -v `pwd`:/mnt mcr.microsoft.com/playwright/java:focal bash -c 'cd /mnt ; mvn package ; java -cp /root/.m2/repository/org/slf4j/slf4j-simple/1.7.7/slf4j-simple-1.7.7.jar:/mnt/sparql.anything.fuseki/target/sparql-anything-fuseki-0.3.0-SNAPSHOT.jar com.github.spiceh2020.sparql.anything.fuseki.Endpoint'
+```

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ WHERE {
 |Option name|Description|Valid Values|Default Value|
 |-|-|-|-|
 |html.selector|A CSS selector that restricts the HTML tags to consider for the triplification.|Any valid CSS selector.|No Value|
-|html.browser|It tells the triplifier to use the specified browser to navigate to the page to obtain HTML.|chromium\|webkit\|firefox|null|
+|html.browser|It tells the triplifier to use the specified browser to navigate to the page to obtain HTML. By default a browser is not used. The use of a browser has some dependencies -- see TODO.md.|chromium\|webkit\|firefox|null|
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ WHERE {
 |Option name|Description|Valid Values|Default Value|
 |-|-|-|-|
 |html.selector|A CSS selector that restricts the HTML tags to consider for the triplification.|Any valid CSS selector.|No Value|
-|html.browser|It tells the triplifier to use the specified browser to navigate to the page to obtain HTML. By default a browser is not used. The use of a browser has some dependencies -- see TODO.md.|chromium\|webkit\|firefox|null|
+|html.browser|It tells the triplifier to use the specified browser to navigate to the page to obtain HTML. By default a browser is not used. The use of a browser has some dependencies -- see [BROWSER](BROWSER.md).|chromium\|webkit\|firefox|null|
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ WHERE {
 |Option name|Description|Valid Values|Default Value|
 |-|-|-|-|
 |html.selector|A CSS selector that restricts the HTML tags to consider for the triplification.|Any valid CSS selector.|No Value|
+|html.browser|It tells the triplifier to use the specified browser to navigate to the page to obtain HTML.|chromium\|webkit\|firefox|null|
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ WHERE {
 |Option name|Description|Valid Values|Default Value|
 |-|-|-|-|
 |html.selector|A CSS selector that restricts the HTML tags to consider for the triplification.|Any valid CSS selector.|No Value|
-|html.browser|It tells the triplifier to use the specified browser to navigate to the page to obtain HTML. By default a browser is not used. The use of a browser has some dependencies -- see [BROWSER](BROWSER.md).|chromium\|webkit\|firefox|null|
+|html.browser|It tells the triplifier to use the specified browser to navigate to the page to obtain HTML. By default a browser is not used. The use of a browser has some dependencies -- see [BROWSER](BROWSER.md).|chromium\|webkit\|firefox|No Value|
 
 </details>
 

--- a/sparql.anything.html/pom.xml
+++ b/sparql.anything.html/pom.xml
@@ -11,6 +11,11 @@
 	</parent>
 	<artifactId>sparql.anything.html</artifactId>
 	<dependencies>
+	<dependency>
+       <groupId>com.microsoft.playwright</groupId>
+       <artifactId>playwright</artifactId>
+       <version>1.13.0</version>
+       </dependency>
 		<dependency>
 			<groupId>com.github.spice-h2020</groupId>
 			<artifactId>sparql.anything.model</artifactId>

--- a/sparql.anything.html/src/main/java/com/github/spiceh2020/sparql/anything/html/HTMLTriplifier.java
+++ b/sparql.anything.html/src/main/java/com/github/spiceh2020/sparql/anything/html/HTMLTriplifier.java
@@ -208,6 +208,7 @@ public class HTMLTriplifier implements Triplifier {
 		Page page = context.newPage() ;
 		page.navigate(url);
 		String htmlFromBrowser = page.content();
+		browser.close();
 		return htmlFromBrowser;
 	}
 


### PR DESCRIPTION
since some webpages have content generated by scripts (executed by the browser) this PR could be useful for extracting data from that script generated content.

e.g.

```
curl --silent 'http://localhost:3000/sparql.anything'  \
--header "Accept: text/csv" \
--data-urlencode 'query=
PREFIX xyz: <http://sparql.xyz/facade-x/data/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX fx: <http://sparql.xyz/facade-x/ns/>
SELECT (count(?s) as ?cnt)
WHERE {
 SERVICE <x-sparql-anything:> {
   fx:properties fx:location "https://www.google.com/search?q=friends" ;
                 fx:media-type "text/html" .
   ?s ?p ?o .
 }
}'
```

```
cnt
5379
```


but you get more content using a browser:
```
curl --silent 'http://localhost:3000/sparql.anything'  \
--header "Accept: text/csv" \
--data-urlencode 'query=
PREFIX xyz: <http://sparql.xyz/facade-x/data/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX fx: <http://sparql.xyz/facade-x/ns/>
SELECT (count(?s) as ?cnt)
WHERE {
 SERVICE <x-sparql-anything:> {
   fx:properties fx:location "https://www.google.com/search?q=friends" ;
                 fx:media-type "text/html" ;
                 fx:html.browser "firefox" .
   ?s ?p ?o .
 }
}'
```


```
cnt
11578
```


also, i didn't add a test yet because Playwright has enough dependencies that i think it is more convenient to run SPARQL-anything in a docker container (rather than installing all the dependencies locally). i made instructions for running in a docker container but i wanted to see what you think first (before i write some tests).