### PR TITLE
Silent keyword

### DIFF
--- a/sparql.anything.csv/src/main/java/com/github/spiceh2020/sparql/anything/csv/CSVTriplifier.java
+++ b/sparql.anything.csv/src/main/java/com/github/spiceh2020/sparql/anything/csv/CSVTriplifier.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.Properties;
 import java.util.Set;
 
+import com.github.spiceh2020.sparql.anything.model.TriplifierHTTPException;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.input.BOMInputStream;
@@ -30,7 +31,7 @@ public class CSVTriplifier implements Triplifier {
 	public final static String PROPERTY_NULLSTRING = "csv.null-string";
 
 	@Override
-	public DatasetGraph triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException {
+	public DatasetGraph triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException, TriplifierHTTPException{
 
 		URL url = Triplifier.getLocation(properties);
 

--- a/sparql.anything.csv/src/test/java/com/github/spiceh2020/sparql/anything/csv/CSVTriplifierTest.java
+++ b/sparql.anything.csv/src/test/java/com/github/spiceh2020/sparql/anything/csv/CSVTriplifierTest.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.Iterator;
 import java.util.Properties;
 
+import com.github.spiceh2020.sparql.anything.model.TriplifierHTTPException;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Node;
@@ -44,13 +45,13 @@ public class CSVTriplifierTest {
 	private CSVTriplifier triplifier = new CSVTriplifier();
 
 	@Test
-	public void testCsvNullStrings() throws IOException {
+	public void testCsvNullStrings() throws IOException, TriplifierHTTPException {
 		testCsvNullString("");
 		testCsvNullString("N/A");
 		testCsvNullString(" ");
 	}
 
-	public void testCsvNullString(String nullString) throws IOException {
+	public void testCsvNullString(String nullString) throws IOException, TriplifierHTTPException {
 		Properties properties = new Properties();
 		properties.setProperty("namespace", "http://www.example.org#");
 		properties.setProperty("csv.null-string", nullString);
@@ -67,7 +68,7 @@ public class CSVTriplifierTest {
 	}
 
 	@Test
-	public void test() throws IOException {
+	public void test() throws IOException, TriplifierHTTPException {
 		Properties properties = new Properties();
 		properties.setProperty("namespace", "http://www.example.org#");
 		URL csv1 = getClass().getClassLoader().getResource("./test1.csv");
@@ -83,7 +84,7 @@ public class CSVTriplifierTest {
 	}
 
 	@Test
-	public void testBNodesFalse() throws IOException {
+	public void testBNodesFalse() throws IOException, TriplifierHTTPException {
 		Properties properties = new Properties();
 		properties.setProperty("namespace", "http://www.example.org#");
 		properties.setProperty("blank-nodes", "false");

--- a/sparql.anything.engine/src/main/java/com/github/spiceh2020/sparql/anything/engine/FacadeX.java
+++ b/sparql.anything.engine/src/main/java/com/github/spiceh2020/sparql/anything/engine/FacadeX.java
@@ -55,7 +55,7 @@ public final class FacadeX {
 			Registry.registerTriplifier("com.github.spiceh2020.sparql.anything.binary.BinaryTriplifier",
 					new String[] { "bin", "dat" }, new String[] { "application/octet-stream" });
 			Registry.registerTriplifier("com.github.spiceh2020.sparql.anything.json.JSONTriplifier",
-					new String[] { "json" }, new String[] { "application/json" });
+					new String[] { "json" }, new String[] { "application/json", "application/problem+json" });
 			Registry.registerTriplifier("com.github.spiceh2020.sparql.anything.spreadsheet.SpreadsheetTriplifier",
 					new String[] { "xls", "xlsx" }, new String[] { "application/vnd.ms-excel",
 							"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" });

--- a/sparql.anything.html/src/main/java/com/github/spiceh2020/sparql/anything/html/HTMLTriplifier.java
+++ b/sparql.anything.html/src/main/java/com/github/spiceh2020/sparql/anything/html/HTMLTriplifier.java
@@ -8,6 +8,7 @@ import java.nio.charset.Charset;
 import java.util.Properties;
 import java.util.Set;
 
+import com.github.spiceh2020.sparql.anything.model.TriplifierHTTPException;
 import com.github.spiceh2020.sparql.anything.model.FacadeXGraphBuilder;
 import org.apache.jena.ext.com.google.common.collect.Sets;
 //import org.apache.jena.graph.NodeFactory;
@@ -45,7 +46,7 @@ public class HTMLTriplifier implements Triplifier {
 	private static final String DOM_NS = "https://html.spec.whatwg.org/#";
 
 	@Override
-	public DatasetGraph triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException {
+	public DatasetGraph triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException, TriplifierHTTPException {
 
 		URL url = Triplifier.getLocation(properties);
 

--- a/sparql.anything.html/src/test/java/com/github/spiceh2020/sparql/anything/html/HTMLTriplifierTest.java
+++ b/sparql.anything.html/src/test/java/com/github/spiceh2020/sparql/anything/html/HTMLTriplifierTest.java
@@ -7,6 +7,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Properties;
 
+import com.github.spiceh2020.sparql.anything.model.TriplifierHTTPException;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.sparql.core.DatasetGraph;
@@ -30,7 +31,7 @@ public class HTMLTriplifierTest {
 	}
 
 	@Test
-	public void test1() throws URISyntaxException, IOException {
+	public void test1() throws URISyntaxException, IOException, TriplifierHTTPException {
 		Properties p = new Properties();
 		p.setProperty(IRIArgument.LOCATION.toString(), new URL(getTestLocation(name.getMethodName())).toString());
 		DatasetGraph dataset = html2rdf.triplify(p);
@@ -46,7 +47,7 @@ public class HTMLTriplifierTest {
 	}
 
 	@Test
-	public void test2() throws URISyntaxException, IOException {
+	public void test2() throws URISyntaxException, IOException, TriplifierHTTPException {
 		Properties p = new Properties();
 		p.setProperty(IRIArgument.LOCATION.toString(), new URL(getTestLocation(name.getMethodName())).toString());
 		DatasetGraph dataset = html2rdf.triplify(p);
@@ -62,7 +63,7 @@ public class HTMLTriplifierTest {
 	}
 
 	@Test
-	public void testBN() {
+	public void testBN() throws TriplifierHTTPException {
 
 		HTMLTriplifier st = new HTMLTriplifier();
 		Properties p = new Properties();

--- a/sparql.anything.json/src/main/java/com/github/spiceh2020/sparql/anything/json/JSONTriplifier.java
+++ b/sparql.anything.json/src/main/java/com/github/spiceh2020/sparql/anything/json/JSONTriplifier.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import com.github.spiceh2020.sparql.anything.model.TriplifierHTTPException;
 import com.github.spiceh2020.sparql.anything.model.BaseFacadeXBuilder;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -45,7 +46,7 @@ public class JSONTriplifier implements Triplifier {
 	}
 
 	private void transform(URL url, Properties properties,
-				FacadeXGraphBuilder builder) throws IOException {
+				FacadeXGraphBuilder builder) throws IOException, TriplifierHTTPException {
 
 		JsonIterator.setMode(DecodingMode.DYNAMIC_MODE_AND_MATCH_FIELD_WITH_HASH);
 		JsonStream.setMode(EncodingMode.DYNAMIC_MODE);
@@ -175,7 +176,7 @@ public class JSONTriplifier implements Triplifier {
 //	}
 
 	@Override
-	public DatasetGraph triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException {
+	public DatasetGraph triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException, TriplifierHTTPException {
 		URL url = Triplifier.getLocation(properties);
 		logger.trace("Triplifying ", url.toString());
 
@@ -190,7 +191,9 @@ public class JSONTriplifier implements Triplifier {
 
 								 @Override
 	public Set<String> getMimeTypes() {
-		return Sets.newHashSet("application/json");
+		Set set = Sets.newHashSet("application/json");
+		// set.add("application/problem+json"); // TODO is this necessary?
+		return set ;
 	}
 
 	@Override

--- a/sparql.anything.json/src/test/java/com/github/spiceh2020/sparql/anything/json/test/JSON2RDFTransformerTest.java
+++ b/sparql.anything.json/src/test/java/com/github/spiceh2020/sparql/anything/json/test/JSON2RDFTransformerTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Properties;
 
+import com.github.spiceh2020.sparql.anything.model.TriplifierHTTPException;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -30,7 +31,7 @@ public class JSON2RDFTransformerTest {
 	private Logger log = LoggerFactory.getLogger(JSON2RDFTransformerTest.class);
 
 	@Test
-	public void testEmptyAndNull() {
+	public void testEmptyAndNull() throws TriplifierHTTPException {
 
 		Triplifier jt = new JSONTriplifier();
 
@@ -76,7 +77,7 @@ public class JSON2RDFTransformerTest {
 	}
 
 	@Test
-	public void testPrimitive() {
+	public void testPrimitive() throws TriplifierHTTPException {
 		{
 
 			{
@@ -134,7 +135,7 @@ public class JSON2RDFTransformerTest {
 	}
 
 	@Test
-	public void testNegative() {
+	public void testNegative() throws TriplifierHTTPException {
 		Triplifier jt = new JSONTriplifier();
 		Properties properties = new Properties();
 		properties.setProperty(IRIArgument.NAMESPACE.toString(), ontologyPrefix);
@@ -163,7 +164,7 @@ public class JSON2RDFTransformerTest {
 	}
 
 	@Test
-	public void keys() {
+	public void keys() throws TriplifierHTTPException {
 		Triplifier jt = new JSONTriplifier();
 		Properties properties = new Properties();
 		Model m = ModelFactory.createDefaultModel();
@@ -187,7 +188,7 @@ public class JSON2RDFTransformerTest {
 	}
 
 	@Test
-	public void testBlankNodeProperty() {
+	public void testBlankNodeProperty() throws TriplifierHTTPException {
 		Triplifier jt = new JSONTriplifier();
 		Properties properties = new Properties();
 		String root = "https://w3id.org/spice/resource/root";
@@ -217,7 +218,7 @@ public class JSON2RDFTransformerTest {
 	}
 
 	@Test
-	public void testBlankNodeFalse() {
+	public void testBlankNodeFalse() throws TriplifierHTTPException {
 		Triplifier jt = new JSONTriplifier();
 		Properties properties = new Properties();
 		String root = "https://w3id.org/spice/resource/root";
@@ -248,7 +249,7 @@ public class JSON2RDFTransformerTest {
 	}
 
 	@Test
-	public void testBlankNodeFalseNoRoot() {
+	public void testBlankNodeFalseNoRoot() throws TriplifierHTTPException {
 		Triplifier jt = new JSONTriplifier();
 		Properties properties = new Properties();
 		String root = getClass().getClassLoader().getResource("./testprimitive.json").toString();
@@ -279,7 +280,7 @@ public class JSON2RDFTransformerTest {
 	}
 
 	@Test
-	public void s() {
+	public void s() throws TriplifierHTTPException {
 		{
 			{
 				Model m = ModelFactory.createDefaultModel();
@@ -364,7 +365,7 @@ public class JSON2RDFTransformerTest {
 
 	@Ignore // Not sure how to reproduce with the new library
 	@Test(expected = JsonException.class)
-	public void testDuplicateKeyJSON() {
+	public void testDuplicateKeyJSON() throws TriplifierHTTPException {
 		{
 			Triplifier jt = new JSONTriplifier();
 			try {
@@ -381,7 +382,7 @@ public class JSON2RDFTransformerTest {
 	}
 
 	@Test
-	public void testUTF8encoded() {
+	public void testUTF8encoded() throws TriplifierHTTPException {
 //		/collection/artworks/p/052/p05259-15628.json {namespace=http://sparql.xyz/facade-x/data/, location=./collection/artworks/p/052/p05259-15628.json
 		String f = "./p05259-15628.json";
 		Triplifier jt = new JSONTriplifier();
@@ -396,7 +397,7 @@ public class JSON2RDFTransformerTest {
 
 	@Ignore // this seems to work now but keeping the test for future reference
 	@Test
-	public void testContainsZerosDebug() {
+	public void testContainsZerosDebug() throws TriplifierHTTPException {
 //		/collection/artworks/p/052/p05259-15628.json {namespace=http://sparql.xyz/facade-x/data/, location=./collection/artworks/p/052/p05259-15628.json
 		String f = "./t09122-23226.json";
 		Triplifier jt = new JSONTriplifier();

--- a/sparql.anything.json/src/test/java/com/github/spiceh2020/sparql/anything/json/test/JSONTripleFilteringTest.java
+++ b/sparql.anything.json/src/test/java/com/github/spiceh2020/sparql/anything/json/test/JSONTripleFilteringTest.java
@@ -21,6 +21,7 @@
 
 package com.github.spiceh2020.sparql.anything.json.test;
 
+import com.github.spiceh2020.sparql.anything.model.TriplifierHTTPException;
 import com.github.spiceh2020.sparql.anything.json.JSONTriplifier;
 import com.github.spiceh2020.sparql.anything.model.FacadeXGraphBuilder;
 import com.github.spiceh2020.sparql.anything.model.IRIArgument;
@@ -52,7 +53,7 @@ public class JSONTripleFilteringTest {
 	}
 
 	@Test
-	public void friendsSinglePattern() throws IOException {
+	public void friendsSinglePattern() throws IOException, TriplifierHTTPException {
 		URL url = getClass().getClassLoader().getResource("./friends.json");
 		JSONTriplifier jt = new JSONTriplifier();
 		Properties properties = new Properties();
@@ -75,7 +76,7 @@ public class JSONTripleFilteringTest {
 	}
 
 	@Test
-	public void friendsMultiplePatterns() throws IOException {
+	public void friendsMultiplePatterns() throws IOException, TriplifierHTTPException {
 		URL url = getClass().getClassLoader().getResource("./friends.json");
 		JSONTriplifier jt = new JSONTriplifier();
 		Properties properties = new Properties();

--- a/sparql.anything.model/src/main/java/com/github/spiceh2020/sparql/anything/model/TriplifierHTTPException.java
+++ b/sparql.anything.model/src/main/java/com/github/spiceh2020/sparql/anything/model/TriplifierHTTPException.java
@@ -1,0 +1,11 @@
+package com.github.spiceh2020.sparql.anything.model;
+
+public class TriplifierHTTPException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public TriplifierHTTPException(String string) {
+		super(string);
+	}
+
+}

--- a/sparql.anything.text/src/main/java/com/github/spiceh2020/sparql/anything/text/TextTriplifier.java
+++ b/sparql.anything.text/src/main/java/com/github/spiceh2020/sparql/anything/text/TextTriplifier.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.github.spiceh2020.sparql.anything.model.TriplifierHTTPException;
 import com.github.spiceh2020.sparql.anything.model.FacadeXGraphBuilder;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
@@ -43,7 +44,7 @@ public class TextTriplifier implements Triplifier {
 //	}
 
 	@Override
-	public DatasetGraph triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException {
+	public DatasetGraph triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException, TriplifierHTTPException {
 //		DatasetGraph dg = DatasetGraphFactory.create();
 
 		String value;
@@ -162,7 +163,7 @@ public class TextTriplifier implements Triplifier {
 	}
 
 	private static String readFromURL(URL url, Properties properties)
-			throws IOException {
+			throws IOException, TriplifierHTTPException {
 		StringWriter sw = new StringWriter();
 //		IOUtils.copy(url.openStream(), sw, Charset.forName(charset));
 		InputStream is = Triplifier.getInputStream(url, properties);

--- a/sparql.anything.text/src/test/java/com/github/spiceh2020/sparql/anything/text/test/TextTriplifierTest.java
+++ b/sparql.anything.text/src/test/java/com/github/spiceh2020/sparql/anything/text/test/TextTriplifierTest.java
@@ -8,6 +8,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Properties;
 
+import com.github.spiceh2020.sparql.anything.model.TriplifierHTTPException;
 import com.github.spiceh2020.sparql.anything.model.IRIArgument;
 import com.github.spiceh2020.sparql.anything.model.Triplifier;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
@@ -26,7 +27,7 @@ import com.github.spiceh2020.sparql.anything.text.TextTriplifier;
 public class TextTriplifierTest {
 
 	@Test
-	public void test1() throws MalformedURLException {
+	public void test1() throws MalformedURLException, TriplifierHTTPException {
 		TextTriplifier tt = new TextTriplifier();
 		File f = new File("src/main/resources/testfile");
 		URL url = f.toURI().toURL();
@@ -47,7 +48,7 @@ public class TextTriplifierTest {
 	}
 
 	@Test
-	public void testRegex() throws MalformedURLException {
+	public void testRegex() throws MalformedURLException, TriplifierHTTPException {
 		TextTriplifier tt = new TextTriplifier();
 		File f = new File("src/main/resources/testfile");
 		URL url = f.toURI().toURL();
@@ -79,7 +80,7 @@ public class TextTriplifierTest {
 	}
 
 	@Test
-	public void testSplit() throws MalformedURLException {
+	public void testSplit() throws MalformedURLException, TriplifierHTTPException {
 		TextTriplifier tt = new TextTriplifier();
 		File f = new File("src/main/resources/testfile");
 		URL url = f.toURI().toURL();

--- a/sparql.anything.xml/src/main/java/com/github/spiceh2020/sparql/anything/xml/XMLTriplifier.java
+++ b/sparql.anything.xml/src/main/java/com/github/spiceh2020/sparql/anything/xml/XMLTriplifier.java
@@ -21,6 +21,7 @@ import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import com.github.spiceh2020.sparql.anything.model.TriplifierHTTPException;
 import com.github.spiceh2020.sparql.anything.model.FacadeXGraphBuilder;
 import org.apache.jena.ext.com.google.common.collect.Sets;
 //import org.apache.jena.graph.NodeFactory;
@@ -43,7 +44,7 @@ public class XMLTriplifier implements Triplifier {
 	private static final Logger log = LoggerFactory.getLogger(XMLTriplifier.class);
 
 	@Override
-	public DatasetGraph triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException {
+	public DatasetGraph triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException, TriplifierHTTPException {
 		URL url = Triplifier.getLocation(properties);
 
 		if (url == null)

--- a/sparql.anything.xml/src/test/java/com/github/spiceh2020/sparql/anything/xml/XMLTriplifierTest.java
+++ b/sparql.anything.xml/src/test/java/com/github/spiceh2020/sparql/anything/xml/XMLTriplifierTest.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.Iterator;
 import java.util.Properties;
 
+import com.github.spiceh2020.sparql.anything.model.TriplifierHTTPException;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
@@ -23,7 +24,7 @@ public class XMLTriplifierTest {
 	public static Logger log = LoggerFactory.getLogger(XMLTriplifierTest.class);
 
 	@Test
-	public void test1() throws IOException {
+	public void test1() throws IOException, TriplifierHTTPException {
 		Properties properties = new Properties();
 		properties.setProperty("baseNamespace", "http://www.example.org#");
 
@@ -37,7 +38,7 @@ public class XMLTriplifierTest {
 	}
 
 	@Test
-	public void testBNodesFalse() throws IOException {
+	public void testBNodesFalse() throws IOException, TriplifierHTTPException {
 		Properties properties = new Properties();
 		properties.setProperty("baseNamespace", "http://www.example.org#");
 		properties.setProperty("blank-nodes", "false");


### PR DESCRIPTION
this starts to address #63 .

it does not handle java.io.FileNotFoundException yet but it does handle the case where a REST API returns HTTP 5xx:

```
curl --silent 'http://localhost:3000/sparql.anything'  \
--header "Accept: text/csv" \
--data-urlencode 'query=
SELECT *
WHERE {
# has data
# bind("OH5100414" as ?id)
# does not have data
bind("OH1251512" as ?id)
bind(iri(concat("x-sparql-anything:media-type=application/json,location=https://echodata.epa.gov/echo/dfr_rest_services.get_dfr?output=JSON&p_id=",?id,"&p_system=PWS_ID")) as ?serv)
service ?serv {
?s ?p ?o .
}
}'
```

yields:
```
Error 500: null
```


but now if you use `silent`
```
curl --silent 'http://localhost:3000/sparql.anything'  \
--header "Accept: text/csv" \
--data-urlencode 'query=
SELECT *
WHERE {
# has data
# bind("OH5100414" as ?id)
# does not have data
bind("OH1251512" as ?id)
bind(iri(concat("x-sparql-anything:media-type=application/json,location=https://echodata.epa.gov/echo/dfr_rest_services.get_dfr?output=JSON&p_id=",?id,"&p_system=PWS_ID")) as ?serv)
service silent ?serv {
?s ?p ?o .
}
}'
```

yields:
```
id,serv,s,p,o
OH1251512,"x-sparql-anything:media-type=application/json,location=https://echodata.epa.gov/echo/dfr_rest_services.get_dfr?output=JSON&p_id=OH1251512&p_system=PWS_ID",,,
```