### PR TITLE
Browser timeout

### DIFF
--- a/BROWSER.md
+++ b/BROWSER.md
@@ -16,7 +16,7 @@ Follow these steps (in a bash shell) to build and run the docker container:
 Once you see Fuseki listening on port 3000 you can run this query (in a bash shell) to see if SPARQL Anything is working:
 
 ```sparql
-curl --silent 'http://localhost:3000/sparql.anything'  \
+curl 'http://localhost:3000/sparql.anything'  \
 -H 'Accept: text/turtle' \
 --data-urlencode 'query=
 PREFIX fx: <http://sparql.xyz/facade-x/ns/>

--- a/BROWSER.md
+++ b/BROWSER.md
@@ -13,6 +13,23 @@ Follow these steps (in a bash shell) to build and run the docker container:
 2) ``docker build -f Dockerfile.development -t sparql-anything-development .``
 3) ``docker run -v sparql-anything_playwright:/ms-playwright -v sparql-anything_m2:/root/.m2 -p 3000:3000 --rm -it -v `pwd`:/app sparql-anything-development``
 
+Once you see Fuseki listening on port 3000 you can run this query (in a bash shell) to see if SPARQL Anything is working:
+
+```sparql
+curl --silent 'http://localhost:3000/sparql.anything'  \
+-H 'Accept: text/turtle' \
+--data-urlencode 'query=
+PREFIX fx: <http://sparql.xyz/facade-x/ns/>
+construct {?s ?p ?o}
+WHERE {
+service <x-sparql-anything:> {
+        fx:properties fx:location "https://www.google.com" .
+        fx:properties fx:media-type "text/html" .
+        ?s ?p ?o .
+    }
+}'
+```
+
 ## Notes
 
 The first time you run a SPARQL query using the headless browser [Playwright](https://playwright.dev/java/) will download the browsers.

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ WHERE {
 |-|-|-|-|
 |html.selector|A CSS selector that restricts the HTML tags to consider for the triplification.|Any valid CSS selector.|No Value|
 |html.browser|It tells the triplifier to use the specified browser to navigate to the page to obtain HTML. By default a browser is not used. The use of a browser has some dependencies -- see [BROWSER](BROWSER.md).|chromium\|webkit\|firefox|No Value|
+|html.browser.timeout|When using a browser to nagivate, it tells the browser if it spends longer than this amount of time (in milliseconds) until a load event is emitted then the operation will timeout. |any integer|30000|
 |html.browser.wait|When using a browser to nagivate, it tells the triplifier to wait for the specified number of seconds (after telling the browser to navigate to the page) before attempting to obtain HTML.|any integer|No Value|
 |html.browser.screenshot|When using a browser to nagivate, take a screenshot of the webpage (perhaps for troubleshooting) and save it here.|a file URI e.g. "file:///tmp/screenshot.png" |No Value|
 

--- a/sparql-anything-html/src/main/java/com/github/sparqlanything/html/HTMLTriplifier.java
+++ b/sparql-anything-html/src/main/java/com/github/sparqlanything/html/HTMLTriplifier.java
@@ -72,6 +72,7 @@ public class HTMLTriplifier implements Triplifier {
 	private static final String PROPERTY_BROWSER = "html.browser";
 	private static final String PROPERTY_BROWSER_WAIT = "html.browser.wait";
 	private static final String PROPERTY_BROWSER_SCREENSHOT = "html.browser.screenshot";
+	private static final String PROPERTY_BROWSER_TIMEOUT = "html.browser.timeout";
 	private static final String HTML_NS = "http://www.w3.org/1999/xhtml#";
 	private static final String DOM_NS = "https://html.spec.whatwg.org/#";
 
@@ -266,14 +267,20 @@ public class HTMLTriplifier implements Triplifier {
 		Page.NavigateOptions options = new Page.NavigateOptions() ;
 		// options.setWaitUntil(WaitUntilState.NETWORKIDLE);
 		// options.setWaitUntil(WaitUntilState.LOAD);
-		// page.navigate(url,options);
-		page.navigate(url);
+		if(properties.containsKey(PROPERTY_BROWSER_TIMEOUT)){
+			Integer timeoutMilliseconds = Integer.parseInt(properties.getProperty(PROPERTY_BROWSER_TIMEOUT));
+			log.debug("headless browser navigatng to url with timeout of {} milliseconds...", timeoutMilliseconds);
+			options.setTimeout(timeoutMilliseconds);
+			page.navigate(url,options);
+		}else{
+			page.navigate(url);
+		}
 		try{
 			if(properties.containsKey(PROPERTY_BROWSER_WAIT)){
-				Integer seconds = Integer.parseInt(properties.getProperty(PROPERTY_BROWSER_WAIT));
-				log.debug("headless browser navigated to url and now we wait for {} seconds...", seconds);
+				Integer waitSeconds = Integer.parseInt(properties.getProperty(PROPERTY_BROWSER_WAIT));
+				log.debug("headless browser navigated to url and now will wait for {} seconds...", waitSeconds);
 				// sleep before we try to pull the HTML content out the the browser
-				java.util.concurrent.TimeUnit.SECONDS.sleep(seconds);
+				java.util.concurrent.TimeUnit.SECONDS.sleep(waitSeconds);
 			}
 			if(properties.containsKey(PROPERTY_BROWSER_SCREENSHOT)){
 				page.screenshot(new Page.ScreenshotOptions()

--- a/sparql-anything-html/src/main/java/com/github/sparqlanything/html/HTMLTriplifier.java
+++ b/sparql-anything-html/src/main/java/com/github/sparqlanything/html/HTMLTriplifier.java
@@ -269,7 +269,7 @@ public class HTMLTriplifier implements Triplifier {
 		// options.setWaitUntil(WaitUntilState.LOAD);
 		if(properties.containsKey(PROPERTY_BROWSER_TIMEOUT)){
 			Integer timeoutMilliseconds = Integer.parseInt(properties.getProperty(PROPERTY_BROWSER_TIMEOUT));
-			log.debug("headless browser navigatng to url with timeout of {} milliseconds...", timeoutMilliseconds);
+			log.debug("headless browser navigating to url with timeout of {} milliseconds", timeoutMilliseconds);
 			options.setTimeout(timeoutMilliseconds);
 			page.navigate(url,options);
 		}else{


### PR DESCRIPTION
my machine was under a heavy load today (many docker containers running) and for some webpages it look longer than the default 30 seconds before the "load" event was emitted by the browser.

this PR allows the user to set the timeout duration.