### PR TITLE
allow quad construction from the cli

### DIFF
--- a/sparql-anything-cli/src/main/java/com/github/sparqlanything/cli/SPARQLAnything.java
+++ b/sparql-anything-cli/src/main/java/com/github/sparqlanything/cli/SPARQLAnything.java
@@ -48,6 +48,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.query.Dataset;
+// import org.apache.jena.sparql.core.DatasetImpl;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecutionFactory;
@@ -161,10 +162,15 @@ public class SPARQLAnything {
 //			pw.println(QueryExecutionFactory.create(q, kb).execAsk());
 		} else if (q.isDescribeType() || q.isConstructType()) {
 			Model m;
+			Dataset d = null;
 			if (q.isConstructType()) {
-				m = QueryExecutionFactory.create(q, kb).execConstruct();
+				d = QueryExecutionFactory.create(q, kb).execConstructDataset();
+				// .execConstructDataset (instead of .execConstruct) so we can construct quads too
+				// as described here: https://jena.apache.org/documentation/query/construct-quad.html
+				m = d.getDefaultModel();
 			} else {
 				m = QueryExecutionFactory.create(q, kb).execDescribe();
+				// d = new DatasetImpl(m);
 			}
 			if (format.equals("JSON")) {
 				// JSON-LD
@@ -180,7 +186,10 @@ public class SPARQLAnything {
 				RDFDataMgr.write(pw, m, Lang.NT);
 			} else if (format.equals("NQ")) {
 				// NQ
-				RDFDataMgr.write(pw, m, Lang.NQ);
+				RDFDataMgr.write(pw, d, Lang.NQ);
+			} else if (format.equals("TRIG")) {
+				// TRIG
+				RDFDataMgr.write(pw, d, Lang.TRIG);
 			} else {
 				throw new RuntimeException("Unsupported format: " + format);
 			}


### PR DESCRIPTION
the fuseki version of sparql anything already allows this.

with this you can now do this:
```
prefix fx: <http://sparql.xyz/facade-x/ns/>
construct { graph <urn:somethinghere> {?s ?p ?o}}
where{
service <x-sparql-anything:>{
fx:properties fx:location "http://www.google.com" .
fx:properties fx:media-type "text/html" .
?s ?p ?o .
}}
```
from the cli.