### PR TITLE
ci/cd: auto release jar files

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Release docker image and jar files
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -34,3 +34,20 @@ jobs:
           build-args: GITHUB_REF=${{ github.ref_name }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - uses: shrink/actions-docker-extract@v3
+        id: extract
+        with:
+          image: ${{ vars.DOCKER_REPO }}
+          path: /app/artifacts/.
+
+      - name: Extract files to release from docker image
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ steps.extract.outputs.destination }}
+          name: artifacts
+
+      - name: Release files
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ steps.extract.outputs.destination }}/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,9 @@ ENV LC_ALL en_US.UTF-8
 ENV HOME "/app"
 
 WORKDIR $HOME
+RUN mkdir $HOME/artifacts
 COPY --from=build $HOME/sparql-anything-fuseki/target/sparql-anything-server-$GITHUB_REF.jar $HOME/sparql-anything-server.jar
+COPY --from=build $HOME/sparql-anything-fuseki/target/sparql-anything-server-$GITHUB_REF.jar $HOME/artifacts/
 
 RUN chown -R 10001:0 $HOME && chmod -R og+rwx $HOME
 USER 10001


### PR DESCRIPTION
This pull request will make sure that upon release, you also add the sparql-anything-server-[version].jar file to the release notes. 

I also want to put the sparql-anything-[version].jar file in there but I can't seem to find it after the mvn install. In what target directory is it located?