### PR TITLE
Create `json.literalize` option

### DIFF
--- a/sparql-anything-json/src/main/java/io/github/sparqlanything/json/JSONTriplifier.java
+++ b/sparql-anything-json/src/main/java/io/github/sparqlanything/json/JSONTriplifier.java
@@ -58,10 +58,10 @@ public class JSONTriplifier implements Triplifier, Slicer<Object> {
 			    In most cases, it is easier to query the JSON using a triple pattern, as in the [example described before](#Example).""", validValues = "Any valid JsonPath (see [JsonSurfer implementation](https://github.com/jsurfer/JsonSurfer)))")
 	public static final IRIArgument PROPERTY_JSONPATH = new IRIArgument("json.path");
 	@Option(description = """
-		One or more key values as filters. E.g. `json.literize=key` or `json.literize.1`, `json.literize.2`, `...` to add multiple expressions.\s
-		The `json.literize` option is only recommended if users need to treat certain JSON elements as opaque string literals, for example, when using GeoJSON.""",
+		One or more key values as filters. E.g. `json.literalize=key` or `json.literalize.1`, `json.literalize.2`, `...` to add multiple expressions.\s
+		The `json.literalize` option is only recommended if users need to treat certain JSON elements as opaque string literals, for example, when using GeoJSON.""",
 		validValues = "Any key values present in the JSON file")
-	public static final IRIArgument PROPERTY_JSONLITERIZE = new IRIArgument("json.literize");
+	public static final IRIArgument PROPERTY_JSONLITERALIZE = new IRIArgument("json.literalize");
 	private static final Logger logger = LoggerFactory.getLogger(JSONTriplifier.class);
 
 	private Set<String> literalKeys = new HashSet<>();
@@ -301,7 +301,7 @@ public class JSONTriplifier implements Triplifier, Slicer<Object> {
 	public void triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException, TriplifierHTTPException {
 
 		List<String> jsonPaths = PropertyUtils.getPropertyValues(properties, "json.path");
-		this.literalKeys = Sets.newHashSet(PropertyUtils.getPropertyValues(properties, PROPERTY_JSONLITERIZE));
+		this.literalKeys = Sets.newHashSet(PropertyUtils.getPropertyValues(properties, PROPERTY_JSONLITERALIZE));
 
 		if (!jsonPaths.isEmpty()) {
 			transformFromJSONPath(properties, builder, jsonPaths);

--- a/sparql-anything-json/src/main/java/io/github/sparqlanything/json/JSONTriplifier.java
+++ b/sparql-anything-json/src/main/java/io/github/sparqlanything/json/JSONTriplifier.java
@@ -43,8 +43,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import static com.fasterxml.jackson.core.JsonToken.END_ARRAY;
-import static com.fasterxml.jackson.core.JsonToken.END_OBJECT;
+import static com.fasterxml.jackson.core.JsonToken.*;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 @io.github.sparqlanything.model.annotations.Triplifier
@@ -58,7 +57,14 @@ public class JSONTriplifier implements Triplifier, Slicer<Object> {
 			    It will pre-process the JSON before the execution of the query.\s
 			    In most cases, it is easier to query the JSON using a triple pattern, as in the [example described before](#Example).""", validValues = "Any valid JsonPath (see [JsonSurfer implementation](https://github.com/jsurfer/JsonSurfer)))")
 	public static final IRIArgument PROPERTY_JSONPATH = new IRIArgument("json.path");
+	@Option(description = """
+		One or more key values as filters. E.g. `json.literize=key` or `json.literize.1`, `json.literize.2`, `...` to add multiple expressions.\s
+		The `json.literize` option is only recommended if users need to treat certain JSON elements as opaque string literals, for example, when using GeoJSON.""",
+		validValues = "Any key values present in the JSON file")
+	public static final IRIArgument PROPERTY_JSONLITERIZE = new IRIArgument("json.literize");
 	private static final Logger logger = LoggerFactory.getLogger(JSONTriplifier.class);
+
+	private Set<String> literalKeys = new HashSet<>();
 
 	private void transform(Properties properties, FacadeXGraphBuilder builder) throws IOException, TriplifierHTTPException {
 
@@ -168,6 +174,11 @@ public class JSONTriplifier implements Triplifier, Slicer<Object> {
 			if (token == JsonToken.FIELD_NAME) {
 				String k = parser.getText();
 				token = parser.nextToken();
+				if (literalKeys.contains(k)) {
+					logger.trace("Literal key found: {}, next token {}", k, token);
+					builder.addValue(dataSourceId, containerId, k, consumeAsString(parser, token));
+					continue;
+				}
 				switch (token) {
 					case START_ARRAY -> {
 						String childContainerIdArr = StringUtils.join(containerId, "/", Triplifier.toSafeURIString(k));
@@ -211,6 +222,45 @@ public class JSONTriplifier implements Triplifier, Slicer<Object> {
 
 	}
 
+	private String consumeAsString(JsonParser parser, JsonToken token) throws IOException {
+		StringBuilder sb = new StringBuilder();
+		if (token == FIELD_NAME) {
+			sb.append(String.format("\"%s\" : ", parser.getText()));
+			token = parser.nextToken();
+		}
+		switch (token) {
+			case START_ARRAY -> {
+				sb.append(START_ARRAY.asString());
+				token = parser.nextToken();
+				while (token != END_ARRAY) {
+					sb.append(consumeAsString(parser, token));
+					sb.append(", ");
+					token = parser.nextToken();
+				}
+				// Remove trailing comma
+				sb.delete(sb.length() - 2, sb.length());
+				sb.append(END_ARRAY.asString());
+			}
+			case START_OBJECT -> {
+				sb.append(START_OBJECT.asString());
+				token = parser.nextToken();
+				while (token != END_OBJECT) {
+					sb.append(consumeAsString(parser, token));
+					sb.append(", ");
+					token = parser.nextToken();
+				}
+				// Remove trailing comma
+				sb.delete(sb.length() - 2, sb.length());
+				sb.append(END_OBJECT.asString());
+			}
+			case VALUE_STRING -> sb.append(String.format("\"%s\"", parser.getValueAsString()));
+			default -> {
+				sb.append(parser.getValueAsString());
+			}
+		}
+		return sb.toString();
+	}
+
 	private void transformMap(Map o, String dataSourceId, String containerId, FacadeXGraphBuilder builder) {
 		for (Map.Entry entry : (Iterable<Map.Entry>) o.entrySet()) {
 			String k = (String) entry.getKey();
@@ -251,6 +301,8 @@ public class JSONTriplifier implements Triplifier, Slicer<Object> {
 	public void triplify(Properties properties, FacadeXGraphBuilder builder) throws IOException, TriplifierHTTPException {
 
 		List<String> jsonPaths = PropertyUtils.getPropertyValues(properties, "json.path");
+		this.literalKeys = Sets.newHashSet(PropertyUtils.getPropertyValues(properties, PROPERTY_JSONLITERIZE));
+
 		if (!jsonPaths.isEmpty()) {
 			transformFromJSONPath(properties, builder, jsonPaths);
 		} else {

--- a/sparql-anything-json/src/test/java/io/github/sparqlanything/json/test/MoreJSONTriplifierTest.java
+++ b/sparql-anything-json/src/test/java/io/github/sparqlanything/json/test/MoreJSONTriplifierTest.java
@@ -110,9 +110,9 @@ public class MoreJSONTriplifierTest extends AbstractTriplifierTester {
 			properties.setProperty("json.path.2", "$..[?(@.number == 2)]");
 		}
 
-		// Json Literize
+		// Json Literalize
 		if (name.getMethodName().equals("testJsonLiteral$1")) {
-			properties.setProperty("json.literize", "literal");
+			properties.setProperty("json.literalize", "literal");
 		}
 	}
 

--- a/sparql-anything-json/src/test/java/io/github/sparqlanything/json/test/MoreJSONTriplifierTest.java
+++ b/sparql-anything-json/src/test/java/io/github/sparqlanything/json/test/MoreJSONTriplifierTest.java
@@ -109,6 +109,11 @@ public class MoreJSONTriplifierTest extends AbstractTriplifierTester {
 			properties.setProperty("json.path.1", "$..[?(@.letter == 'A')]");
 			properties.setProperty("json.path.2", "$..[?(@.number == 2)]");
 		}
+
+		// Json Literize
+		if (name.getMethodName().equals("testJsonLiteral$1")) {
+			properties.setProperty("json.literize", "literal");
+		}
 	}
 
 	@Test
@@ -205,5 +210,11 @@ public class MoreJSONTriplifierTest extends AbstractTriplifierTester {
 	public void testMultiJsonPath$1() {
 		logger.debug("Test multiple json paths (one go + JsonPath)");
 		Assert.assertEquals(13, result.size());
+	}
+
+	@Test
+	public void testJsonLiteral$1() {
+		logger.debug("Test simple Json literal (one go)");
+		assertResultIsIsomorphicWithExpected();
 	}
 }

--- a/sparql-anything-json/src/test/resources/JsonLiteral.json
+++ b/sparql-anything-json/src/test/resources/JsonLiteral.json
@@ -1,0 +1,25 @@
+{
+  "child" : {
+    "literal" : {
+      "x" : 1,
+      "y" : 2
+    },
+    "non-literal" : {
+      "a" : 1,
+      "b" : 2
+    }
+  },
+  "literal" : {
+    "first" : 1,
+    "second" : "second"
+  },
+  "literal_string" : {
+    "literal" : "value"
+  },
+  "literal_bool" : {
+    "literal" : true
+  },
+  "literal_int" : {
+    "literal" : 9
+  }
+}

--- a/sparql-anything-json/src/test/resources/JsonLiteral.ttl
+++ b/sparql-anything-json/src/test/resources/JsonLiteral.ttl
@@ -1,0 +1,36 @@
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix fx:   <http://sparql.xyz/facade-x/ns/>.
+@prefix xyz:  <http://sparql.xyz/facade-x/data/>.
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#>.
+
+<http://www.example.org/document>
+        a       <http://sparql.xyz/facade-x/ns/root> ;
+        xyz:child    <http://www.example.org/document/child> ;
+        xyz:literal  "{\"first\" : 1, \"second\" : \"second\"}" ;
+        xyz:literal_string <http://www.example.org/document/literal_string> ;
+        xyz:literal_bool <http://www.example.org/document/literal_bool> ;
+        xyz:literal_int <http://www.example.org/document/literal_int> ;
+        .
+
+<http://www.example.org/document/child>
+        xyz:literal      "{\"x\" : 1, \"y\" : 2}" ;
+        xyz:non-literal  <http://www.example.org/document/child/non-literal> ;
+        .
+
+<http://www.example.org/document/child/non-literal>
+        xyz:a   "1"^^xsd:int ;
+        xyz:b   "2"^^xsd:int ;
+        .
+
+<http://www.example.org/document/literal_string>
+        xyz:literal "\"value\"" ;
+        .
+
+<http://www.example.org/document/literal_bool>
+        xyz:literal "true" ;
+        .
+
+<http://www.example.org/document/literal_int>
+        xyz:literal "9" ;
+        .


### PR DESCRIPTION
This PR introduces the `json.literalize` config option which can be used to handle a certain JSON key as a string literal rather than a JSON object. This is especially useful for GeoJSON where this option can be used to literalize geometry literals instead of having to reconstruct them.

Completes #524 

> [!NOTE]
> I'm open to also adding a more general option but it may require significant refactors (namely to `Triplifier` to ensure that there is some way to consume a key as a literal instead of triplifying it)