### PR TITLE
Added ExpandPrefix and ExpandPrefixedName functions from TARQL.

### DIFF
--- a/sparql-anything-engine/src/main/java/io/github/sparqlanything/engine/FacadeX.java
+++ b/sparql-anything-engine/src/main/java/io/github/sparqlanything/engine/FacadeX.java
@@ -174,7 +174,24 @@ public final class FacadeX {
 			log.error("", e);
 		}
 
+		try {
+			FunctionRegistry.get().put(Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "LevenshteinDistance", ReflectionFunctionFactory.get().makeFunction(true, LevenshteinDistance.class.getMethod("apply", CharSequence.class, CharSequence.class)));
+			FunctionRegistry.get().put(Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "JaccardDistance", ReflectionFunctionFactory.get().makeFunction(true, JaccardDistance.class.getMethod("apply", CharSequence.class, CharSequence.class)));
+			FunctionRegistry.get().put(Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "JaroWinklerDistance", ReflectionFunctionFactory.get().makeFunction(true, JaroWinklerDistance.class.getMethod("apply", CharSequence.class, CharSequence.class)));
+			FunctionRegistry.get().put(Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "LongestCommonSubsequenceDistance", ReflectionFunctionFactory.get().makeFunction(true, LongestCommonSubsequenceDistance.class.getMethod("apply", CharSequence.class, CharSequence.class)));
+			FunctionRegistry.get().put(Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "HammingDistance", ReflectionFunctionFactory.get().makeFunction(true, HammingDistance.class.getMethod("apply", CharSequence.class, CharSequence.class)));
+			FunctionRegistry.get().put(Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "QGramDistance", ReflectionFunctionFactory.get().makeFunction(true, QGram.class.getMethod("distance", String.class, String.class)));
+			FunctionRegistry.get().put(Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "CosineDistance", ReflectionFunctionFactory.get().makeFunction(true, Cosine.class.getMethod("distance", String.class, String.class)));
+		} catch (NoSuchMethodException e) {
+			log.error("", e);
+		}
+
 		log.trace("Enabling function `serial`");
 		FunctionRegistry.get().put(Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "serial", Serial.class);
+
+		log.trace("Enabling functions `expandPrefix` and `expandPrefixedName`");
+		FunctionRegistry.get().put(Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "expandPrefix", ExpandPrefixFunction.class);
+		FunctionRegistry.get().put(Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "expandPrefixedName", ExpandPrefixedNameFunction.class);
+
 	}
 }

--- a/sparql-anything-engine/src/main/java/io/github/sparqlanything/engine/functions/ExpandPrefixFunction.java
+++ b/sparql-anything-engine/src/main/java/io/github/sparqlanything/engine/functions/ExpandPrefixFunction.java
@@ -1,0 +1,98 @@
+package io.github.sparqlanything.engine.functions;
+
+import io.github.sparqlanything.model.Triplifier;
+import io.github.sparqlanything.model.annotations.FXFunctionDoc;
+import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryBuildException;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.shared.impl.PrefixMappingImpl;
+import org.apache.jena.sparql.ARQConstants;
+import org.apache.jena.sparql.ARQInternalErrorException;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.expr.ExprEvalException;
+import org.apache.jena.sparql.expr.ExprList;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.function.FunctionBase1;
+import org.apache.jena.sparql.function.FunctionEnv;
+import org.apache.jena.sparql.util.Context;
+import org.apache.jena.sparql.util.Symbol;
+
+@FXFunctionDoc(
+	description = "fx:expandPrefix(?p) returns expanded prefix defined in the query to its associated namespace IRI." +
+		"Originally developped within TARQL project and ported to SPARQL-Anything with minimal changes to maximise reuse.",
+	example = "BIND(STR(fx:expandPrefix(?px)) as ?expx)",
+	group = "FUNCTIONS",
+	label = "fx:expandPrefix"
+)
+public class ExpandPrefixFunction extends FunctionBase1 implements FXFunction {
+
+	public static String IRI = Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "expandPrefix";
+	public static String NAME = "fx:expandPrefix";
+	public static final Symbol PREFIX_MAPPING = Symbol.create("prefixMapping");
+	private PrefixMapping prefixes;
+
+	public ExpandPrefixFunction() {
+		super();
+	}
+
+	public NodeValue exec(NodeValue prefix, Context context) {
+		if (prefix == null) {
+			return null;
+		}
+		if (!prefix.isString()) {
+			throw new ExprEvalException(NAME + ": not a string: " + prefix);
+		}
+		prefixes = get_prefix_mapping(context);
+		if (prefixes == null) {
+			throw new ExprEvalException(NAME + ": no prefix mapping registered");
+		}
+		String iri = prefixes.getNsPrefixURI(prefix.asString());
+		if (iri == null) {
+			throw new ExprEvalException(NAME + ": prefix not defined: " + prefix);
+		}
+		return exec(prefix);
+	}
+
+	@Override
+	public NodeValue exec(Binding binding, ExprList args, String uri, FunctionEnv env) {
+		if (args == null) {
+			throw new ARQInternalErrorException("ExpandPrefixFunction: Null args list");
+		}
+		if (args.size() != 1) {
+			throw new ExprEvalException("ExpandPrefixFunction: Wrong number of arguments: Wanted 1, got " + args.size());
+		}
+        return exec(args.get(0).eval(binding, env), env.getContext());
+	}
+
+	@Override
+	public NodeValue exec(NodeValue prefix) {
+		String iri = prefixes.getNsPrefixURI(prefix.asString());
+		if (iri == null) {
+			throw new ExprEvalException(NAME + ": prefix not defined: " + prefix);
+		}
+
+		return NodeValue.makeString(iri);
+	}
+
+
+	@Override
+	public void checkBuild(String uri, ExprList args) {
+		if (args.size() != 1) {
+			throw new QueryBuildException("Function '" + Lib.className(this) + "' takes one argument");
+		}
+	}
+
+	private PrefixMapping get_prefix_mapping(Context context) {
+		prefixes = context.get(PREFIX_MAPPING);
+		if (prefixes == null) {
+			prefixes = new PrefixMappingImpl();
+			Query query = context.get(ARQConstants.sysCurrentQuery);
+			prefixes.setNsPrefixes(query.getPrefixMapping());
+			context.set(ExpandPrefixFunction.PREFIX_MAPPING, prefixes);
+		}
+
+		return prefixes;
+	}
+
+}

--- a/sparql-anything-engine/src/main/java/io/github/sparqlanything/engine/functions/ExpandPrefixedNameFunction.java
+++ b/sparql-anything-engine/src/main/java/io/github/sparqlanything/engine/functions/ExpandPrefixedNameFunction.java
@@ -1,0 +1,91 @@
+package io.github.sparqlanything.engine.functions;
+
+import io.github.sparqlanything.model.Triplifier;
+import io.github.sparqlanything.model.annotations.FXFunctionDoc;
+import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryBuildException;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.shared.impl.PrefixMappingImpl;
+import org.apache.jena.sparql.ARQConstants;
+import org.apache.jena.sparql.ARQInternalErrorException;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.expr.ExprEvalException;
+import org.apache.jena.sparql.expr.ExprList;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.function.FunctionBase1;
+import org.apache.jena.sparql.function.FunctionEnv;
+import org.apache.jena.sparql.util.Context;
+
+@FXFunctionDoc(
+	description = "fx:expandPrefixName(?p) returns expands a prefixed name, such as dc:title, using any prefixes" +
+		" defined in the query. The result is an IRI. Originally developped within TARQL project and ported to " +
+		"SPARQL-Anything with minimal changes to maximise reuse.",
+	example = "BIND(STR(fx:expandPrefixName(?px)) as ?expx)",
+	group = "FUNCTIONS",
+	label = "fx:expandPrefixedName"
+)
+public class ExpandPrefixedNameFunction extends FunctionBase1 implements FXFunction {
+
+	public static String IRI = Triplifier.FACADE_X_CONST_NAMESPACE_IRI + "expandPrefixedName";
+	public static String NAME = "fx:expandPrefixedName";
+	private PrefixMapping prefixes;
+
+	public ExpandPrefixedNameFunction() {
+		super();
+	}
+	
+	public NodeValue exec(NodeValue name, Context context) {
+		if (name == null) return null;
+		if (!name.isString()) throw new ExprEvalException(NAME + ": not a string: " + name);
+		prefixes = get_prefix_mapping(context);
+		if (prefixes == null) throw new ExprEvalException(NAME + ": no prefix mapping registered");
+
+		return exec(name);
+	}
+
+	@Override
+	public NodeValue exec(Binding binding, ExprList args, String uri, FunctionEnv env) {
+		if (args == null) {
+			throw new ARQInternalErrorException(NAME + ": null args list");
+		}
+		if (args.size() != 1) {
+			throw new ExprEvalException(NAME + ": wrong number of arguments: Wanted 1, got " + args.size());
+		}
+        return exec(args.get(0).eval(binding, env), env.getContext());
+	}
+
+	@Override
+	public NodeValue exec(NodeValue name) {
+		String pname = name.asString();
+		int idx = pname.indexOf(':');
+		if (idx == -1) throw new ExprEvalException(NAME + ": not a prefixed name: " + name);
+		String prefix = pname.substring(0, idx);
+		String iri = prefixes.getNsPrefixURI(prefix);
+		if (iri == null) throw new ExprEvalException(NAME + ": prefix not defined: " + prefix);
+
+		return NodeValue.makeNode(NodeFactory.createURI(iri + pname.substring(idx + 1)));
+	}
+
+
+	@Override
+	public void checkBuild(String uri, ExprList args) {
+		if (args.size() != 1) {
+			throw new QueryBuildException("Function '" + Lib.className(this) + "' takes one argument");
+		}
+	}
+
+	private PrefixMapping get_prefix_mapping(Context context) {
+		prefixes = context.get(ExpandPrefixFunction.PREFIX_MAPPING);
+		if (prefixes == null) {
+			prefixes = new PrefixMappingImpl();
+			Query query = context.get(ARQConstants.sysCurrentQuery);
+			prefixes.setNsPrefixes(query.getPrefixMapping());
+			context.set(ExpandPrefixFunction.PREFIX_MAPPING, prefixes);
+		}
+
+		return prefixes;
+	}
+
+}

--- a/sparql-anything-engine/src/test/java/io/github/sparqlanything/engine/test/ExpandPrefixTest.java
+++ b/sparql-anything-engine/src/test/java/io/github/sparqlanything/engine/test/ExpandPrefixTest.java
@@ -1,0 +1,48 @@
+package io.github.sparqlanything.engine.test;
+
+import io.github.sparqlanything.model.Triplifier;
+import org.apache.jena.sparql.expr.ExprEvalException;
+import org.apache.jena.sparql.expr.VariableNotBoundException;
+import org.apache.jena.vocabulary.DC;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+
+public class ExpandPrefixTest extends PrefixFunctionsTest {
+	
+	@Test
+	public void testSuccess() {
+		assertEval(stringNode(Triplifier.FACADE_X_CONST_NAMESPACE_IRI), "fx:expandPrefix('fx')");
+	}
+	
+	@Test
+	public void testSuccess2() {
+		prefixes.setNsPrefix("dc", DC.NS);
+		assertEval(stringNode(DC.NS), "fx:expandPrefix('dc')");
+	}
+
+	@Test
+	public void testUnboundArg() {
+		try {
+			eval("fx:expandPrefix(?unbound)");
+			fail();
+		} catch (VariableNotBoundException ex) {}
+	}
+
+	@Test
+	public void testNonStringArg() {
+		try {
+			eval("fx:expandPrefix(true)");
+			fail();
+		} catch (ExprEvalException ex) {}
+	}
+	
+	@Test
+	public void testUndefinedPrefix() {
+		try {
+			eval("fx:expandPrefix('dc')");
+			fail();
+		} catch (ExprEvalException ex) {}
+	}
+}

--- a/sparql-anything-engine/src/test/java/io/github/sparqlanything/engine/test/ExpandPrefixedNameTest.java
+++ b/sparql-anything-engine/src/test/java/io/github/sparqlanything/engine/test/ExpandPrefixedNameTest.java
@@ -1,0 +1,73 @@
+package io.github.sparqlanything.engine.test;
+
+import io.github.sparqlanything.engine.functions.ExpandPrefixedNameFunction;
+import org.apache.jena.sparql.expr.ExprEvalException;
+import org.apache.jena.sparql.expr.VariableNotBoundException;
+import org.apache.jena.vocabulary.DC;
+import org.junit.Test;
+
+import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.junit.Assert.fail;
+
+
+public class ExpandPrefixedNameTest extends PrefixFunctionsTest {
+	
+	@Test
+	public void testSuccess() {
+		assertEval(createURI(ExpandPrefixedNameFunction.IRI), "fx:expandPrefixedName('fx:expandPrefixedName')");
+	}
+	
+	@Test
+	public void testSuccess2() {
+		prefixes.setNsPrefix("dc", DC.NS);
+		assertEval(createURI(DC.NS + "title"), "fx:expandPrefixedName('dc:title')");
+	}
+
+	@Test
+	public void testUnboundArg() {
+		try {
+			eval("fx:expandPrefixedName(?unbound)");
+			fail();
+		} catch (VariableNotBoundException ex) {}
+	}
+
+	@Test
+	public void testNonStringArg() {
+		try {
+			eval("fx:expandPrefixedName(true)");
+			fail();
+		} catch (ExprEvalException ex) {}
+	}
+	
+	@Test
+	public void testUndefinedPrefix() {
+		try {
+			eval("fx:expandPrefixedName('dc')");
+			fail();
+		} catch (ExprEvalException ex) {}
+	}
+	
+	@Test
+	public void testNotAPrefixedName1() {
+		try {
+			eval("fx:expandPrefixedName('')");
+			fail();
+		} catch (ExprEvalException ex) {}
+	}
+	
+	@Test
+	public void testNotAPrefixedName2() {
+		try {
+			eval("fx:expandPrefixedName(':')");
+			fail();
+		} catch (ExprEvalException ex) {}
+	}
+	
+	@Test
+	public void testNotAPrefixedName3() {
+		try {
+			eval("fx:expandPrefixedName(':a a')");
+			fail();
+		} catch (ExprEvalException ex) {}
+	}
+}

--- a/sparql-anything-engine/src/test/java/io/github/sparqlanything/engine/test/PrefixFunctionsTest.java
+++ b/sparql-anything-engine/src/test/java/io/github/sparqlanything/engine/test/PrefixFunctionsTest.java
@@ -1,0 +1,47 @@
+package io.github.sparqlanything.engine.test;
+
+import io.github.sparqlanything.engine.functions.ExpandPrefixFunction;
+import io.github.sparqlanything.engine.functions.ExpandPrefixedNameFunction;
+import io.github.sparqlanything.model.Triplifier;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.shared.impl.PrefixMappingImpl;
+import org.apache.jena.sparql.engine.binding.BindingFactory;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.function.FunctionEnv;
+import org.apache.jena.sparql.function.FunctionEnvBase;
+import org.apache.jena.sparql.function.FunctionRegistry;
+import org.apache.jena.sparql.util.ExprUtils;
+import org.junit.Before;
+
+import static org.junit.Assert.assertEquals;
+
+
+public abstract class PrefixFunctionsTest {
+	protected PrefixMapping prefixes;
+	protected FunctionEnv env;
+	
+	@Before
+	public void setUp() {
+		prefixes = new PrefixMappingImpl();
+		prefixes.setNsPrefix("fx", Triplifier.FACADE_X_CONST_NAMESPACE_IRI);
+		env = new FunctionEnvBase();
+		env.getContext().set(ExpandPrefixFunction.PREFIX_MAPPING, prefixes);
+		FunctionRegistry.get().put(ExpandPrefixFunction.IRI, ExpandPrefixFunction.class);
+		FunctionRegistry.get().put(ExpandPrefixedNameFunction.IRI, ExpandPrefixedNameFunction.class);
+	}
+
+	protected void assertEval(Node expected, String expression) {
+		assertEquals(expected, eval(expression));
+	}
+	
+	protected Node eval(String expression) {
+		Expr expr = ExprUtils.parse(expression, prefixes);
+		return expr.eval(BindingFactory.root(), env).asNode();
+	}
+
+	protected Node stringNode(String s) {
+		return NodeFactory.createLiteralString(s);
+	}
+}


### PR DESCRIPTION
In response to https://github.com/SPARQL-Anything/sparql.anything/issues/627

Ported [TARQL](https://github.com/tarql/tarql) functions to SPARQL-Anything

[ExpandPrefixFunction](https://github.com/tarql/tarql/blob/master/src/main/java/org/deri/tarql/functions/ExpandPrefixFunction.java)

[ExpandPrefixedNameFunction](https://github.com/tarql/tarql/blob/master/src/main/java/org/deri/tarql/functions/ExpandPrefixedNameFunction.java)